### PR TITLE
Issue #35: Bump required "catalog" version to 0.19.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "~7.0.0",
-        "lizards-and-pumpkins/catalog": "~0.18.0"
+        "lizards-and-pumpkins/catalog": "~0.19.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7",


### PR DESCRIPTION
Closes #35.